### PR TITLE
Disabled minify for all build types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.nonTransitiveRClass=true
 # Maven
 POM_NAME=Flowly
 POM_PACKAGING=aar
-VERSION_NAME=1.0.0-alpha2
+VERSION_NAME=1.0.0-alpha3
 GROUP=com.zeoflow.flowly
 POM_DESCRIPTION=Helps you manage your app states easier.
 POM_URL=https://github.com/zeoflow/flowly

--- a/process/build.gradle
+++ b/process/build.gradle
@@ -9,11 +9,11 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
         }
 
         releaseDebuggable {
-            minifyEnabled true
+            minifyEnabled false
             debuggable true
         }
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -9,11 +9,11 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
         }
 
         releaseDebuggable {
-            minifyEnabled true
+            minifyEnabled false
             debuggable true
         }
 


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #6
### Description
Disabled minify for all build types

###### [Contributing](https://github.com/zeoflow/flowly/blob/master/docs/contributing.md) has more information and tips for a great pull request.